### PR TITLE
0.17.0 testing: bugfixed: the ending '.md' should no longer captured …

### DIFF
--- a/nics/compile/__init__.py
+++ b/nics/compile/__init__.py
@@ -54,9 +54,9 @@ def header_writer(tree: AbsPath) -> str:
             fd_pth = os.path.join(pth, fd)
 
             ## this guarantees a match as the tree/ contents have already been inspected
-            res = re.match(r'(?:\d+ - )?(?P<name>[\w -.]+)(?:.md)?', fd)
+            res = re.match(r'(?:\d+ - )?(?P<name>[\w -.]+?)(?:.md)?', fd)
             name = res.group('name')
-            name_but_in_url = name.replace(' ', '-').replace('.', '-')  # replace all spaces and periods with hyphen
+            name_but_in_url = name.replace(' ', '-')  # replace all spaces and periods with hyphen
             printer(f'DEBUG: name: {repr(name)}  name_but_in_url: {repr(name_but_in_url)}')
 
             if os.path.isdir(fd_pth):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nics"
-version = "0.16.0"
+version = "0.17.0"
 description = "Automated docs repo generator"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
…in regex

trying to fix the issue where .md endings are also getting captured:
![a](https://github.com/nvfp/now-i-can-sleep/assets/102074642/1c8814b4-3b02-4bb0-9e58-f097c6c7fe7f)
